### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.1
   - 7.2
   - hhvm
+  - nightly
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo hhvm.php7.all=1 >> /etc/hhvm/php.ini; fi
@@ -19,3 +20,4 @@ after_script:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly

--- a/src/Message.php
+++ b/src/Message.php
@@ -351,7 +351,7 @@ abstract class Message
     {
         $message = $this->getHead();
 
-        if (isset($this->body)) {
+        if ($this->body) {
             $message .= (string) $this->body;
         }
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -351,7 +351,7 @@ abstract class Message
     {
         $message = $this->getHead();
 
-        if ($this->body) {
+        if (isset($this->body)) {
             $message .= (string) $this->body;
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -867,7 +867,7 @@ class Request extends Message
             $this->path = substr($requestUri, 0, $pos);
             $queryString = substr($requestUri, $pos + 1);
 
-            if ($queryString === false) {
+            if ($queryString === '') {
                 $this->queryString = '';
                 $this->query = [];
             } else {

--- a/src/Response.php
+++ b/src/Response.php
@@ -92,7 +92,7 @@ class Response extends Message
         list ($line, $protocolVersion, $statusCode) = $matches;
 
         $responseObject->setProtocolVersion($protocolVersion);
-        $responseObject->setStatusCode($statusCode);
+        $responseObject->setStatusCode((int)$statusCode);
 
         $response = substr($response, strlen($line));
 

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -25,6 +25,21 @@ class CookieTest extends TestCase
         $this->assertFalse($cookie->isHttpOnly());
     }
 
+    public function testIsHostOnlyShouldReturnTrue()
+    {
+        $cookie = new Cookie('foo', 'bar');
+
+        $this->assertTrue($cookie->isHostOnly());
+    }
+
+    public function testIsHostOnlyShouldReturnFalse()
+    {
+        $cookie = new Cookie('foo', 'bar');
+        $cookie->setDomain('http://localhost');
+
+        $this->assertFalse($cookie->isHostOnly());
+    }
+
     /**
      * @dataProvider providerParse
      *

--- a/tests/MessageBodyResourceTest.php
+++ b/tests/MessageBodyResourceTest.php
@@ -7,7 +7,7 @@ use Brick\Http\MessageBodyResource;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit tests for class Path.
+ * Unit tests for class MessageBodyResource.
  */
 class MessageBodyResourceTest extends TestCase
 {
@@ -26,11 +26,5 @@ class MessageBodyResourceTest extends TestCase
     public function testGetSizeShouldReturnZero()
     {
         $this->assertSame(0, $this->messageBodyResource->getSize());
-    }
-
-    public function testClassInstanceShouldReturnString()
-    {
-        $messageBodyResource = new MessageBodyResource(fopen('php://input', 'rb'));
-        $this->assertEquals('', $messageBodyResource);
     }
 }

--- a/tests/MessageBodyResourceTest.php
+++ b/tests/MessageBodyResourceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Brick\Http\Tests;
+
+use Brick\Http\MessageBodyResource;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for class Path.
+ */
+class MessageBodyResourceTest extends TestCase
+{
+    protected $messageBodyResource;
+
+    public function setUp()
+    {
+        $this->messageBodyResource = new MessageBodyResource(fopen('php://input', 'rb'));
+    }
+
+    public function testRead()
+    {
+        $this->assertSame('', $this->messageBodyResource->read(1));
+    }
+
+    public function testGetSizeShouldReturnZero()
+    {
+        $this->assertSame(0, $this->messageBodyResource->getSize());
+    }
+
+    public function testClassInstanceShouldReturnString()
+    {
+        $messageBodyResource = new MessageBodyResource(fopen('php://input', 'rb'));
+        $this->assertEquals('', $messageBodyResource);
+    }
+}

--- a/tests/MessageBodyStringTest.php
+++ b/tests/MessageBodyStringTest.php
@@ -16,5 +16,8 @@ class MessageBodyStringtTest extends TestCase
         $messageBodyString = new MessageBodyString('<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><meta http-equiv="X-UA-Compatible" content="ie=edge"><title>Document</title></head><body></body></html>');
 
         $this->assertSame('<!DOCTYPE html>', $messageBodyString->read(15));
+        $this->assertSame(232, $messageBodyString->getSize());
+
+        $this->assertSame('<html lang="en">', $messageBodyString->read(16));
     }
 }

--- a/tests/MessageBodyStringTest.php
+++ b/tests/MessageBodyStringTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for class MessageBodyString.
  */
-class MessageBodyStringtTest extends TestCase
+class MessageBodyStringTest extends TestCase
 {
     public function testRead()
     {

--- a/tests/MessageBodyStringTest.php
+++ b/tests/MessageBodyStringTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Brick\Http\Tests;
+
+use Brick\Http\MessageBodyString;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for class MessageBodyString.
+ */
+class MessageBodyStringtTest extends TestCase
+{
+    public function testRead()
+    {
+        $messageBodyString = new MessageBodyString('<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><meta http-equiv="X-UA-Compatible" content="ie=edge"><title>Document</title></head><body></body></html>');
+
+        $this->assertSame('<!DOCTYPE html>', $messageBodyString->read(15));
+    }
+}

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Brick\Http\Tests;
+
+use Brick\Http\Path;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for class Path.
+ */
+class PathTest extends TestCase
+{
+    protected $path;
+
+    public function setUp()
+    {
+        $this->path = new Path('/path1/path2');
+    }
+
+    public function testGetParts()
+    {
+        $result = $this->path->getParts();
+
+        $this->assertCount(2, $result);
+        $this->assertSame('path1', $result[0]);
+        $this->assertSame('path2', $result[1]);
+    }
+
+    public function testContains()
+    {
+        $resultTrue = $this->path->contains('path1');
+        $resultFalse = $this->path->contains('path3');
+
+        $this->assertTrue($resultTrue);
+        $this->assertFalse($resultFalse);
+    }
+
+    public function testStartsWith()
+    {
+        $resultTrue = $this->path->startsWith('/path1');
+        $resultFalse = $this->path->startsWith('/path3');
+
+        $this->assertTrue($resultTrue);
+        $this->assertFalse($resultFalse);
+    }
+
+    public function testEndsWith()
+    {
+        $resultTrue = $this->path->endsWith('/path2');
+        $resultFalse = $this->path->endsWith('/path3');
+
+        $this->assertTrue($resultTrue);
+        $this->assertFalse($resultFalse);
+    }
+}

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -29,28 +29,19 @@ class PathTest extends TestCase
 
     public function testContains()
     {
-        $resultTrue = $this->path->contains('path1');
-        $resultFalse = $this->path->contains('path3');
-
-        $this->assertTrue($resultTrue);
-        $this->assertFalse($resultFalse);
+        $this->assertTrue($this->path->contains('path1'));
+        $this->assertFalse($this->path->contains('path3'));
     }
 
     public function testStartsWith()
     {
-        $resultTrue = $this->path->startsWith('/path1');
-        $resultFalse = $this->path->startsWith('/path3');
-
-        $this->assertTrue($resultTrue);
-        $this->assertFalse($resultFalse);
+        $this->assertTrue($this->path->startsWith('/path1'));
+        $this->assertFalse($this->path->startsWith('/path3'));
     }
 
     public function testEndsWith()
     {
-        $resultTrue = $this->path->endsWith('/path2');
-        $resultFalse = $this->path->endsWith('/path3');
-
-        $this->assertTrue($resultTrue);
-        $this->assertFalse($resultFalse);
+        $this->assertTrue($this->path->endsWith('/path2'));
+        $this->assertFalse($this->path->endsWith('/path3'));
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1034,6 +1034,92 @@ class RequestTest extends TestCase
     }
 
     /**
+     * @expectedException        Brick\Http\Exception\HttpBadRequestException
+     * @expectedExceptionMessage Invalid protocol: invalid_protocol
+     */
+    public function testGetCurrentShouldReturnHttpBadRequestException()
+    {
+        $request = new Request();
+        $_SERVER['SERVER_PROTOCOL'] = 'invalid_protocol';
+        $request->getCurrent();
+    }
+
+    public function testSetFiles()
+    {
+        $request = new Request();
+        $result = $request->setFiles(['./uploaded_file']);
+        $this->assertInstanceOf(Request::class, $result);
+        $this->assertContains('./uploaded_file', $request->getFiles());
+    }
+
+    public function testSetCookiesShouldRemoveCookieHeader()
+    {
+        $request = new Request();
+        $result = $request->setCookies([]);
+        $this->assertCount(0, $result->getCookie());
+    }
+
+    public function testSetRequestUriWithNoQueryString()
+    {
+        $request = new Request();
+        $result = $request->setRequestUri('http://localhost?');
+        $this->assertInstanceOf(Request::class, $result);
+        $this->assertContains('http://localhost?', $result->getRequestUri());
+    }
+
+    public function testGetAcceptShouldReturnEmptyArray()
+    {
+        $request = new Request();
+        $this->assertCount(0, $request->setUrl('http://localhost:8000')->getAccept());
+    }
+
+    public function testIsAjaxShouldReturnFalse()
+    {
+        $request = new Request();
+        $this->assertFalse($request->isAjax());
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The URL provided is not valid.
+     */
+    public function testSetUrlWithInvalidUrl()
+    {
+        $request = new Request();
+        $request->setUrl('http:////invalid_url');
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The URL must have a scheme.
+     */
+    public function testSetUrlWithNoUrlScheme()
+    {
+        $request = new Request();
+        $request->setUrl('invalid_protocol://invalid_url');
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The URL scheme "ftp" is not acceptable.
+     */
+    public function testSetUrlWithUnsupportedProtocol()
+    {
+        $request = new Request();
+        $request->setUrl('ftp://invalid_url');
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The URL must have a host name.
+     */
+    public function testSetUrlWithNoHostName()
+    {
+        $request = new Request();
+        $request->setUrl('http:sub.site.org');
+    }
+
+    /**
      * @dataProvider providerAcceptLanguage
      *
      * @param string $acceptLanguage The Accept-Language header.

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -4,6 +4,7 @@ namespace Brick\Http\Tests;
 
 use Brick\Http\Cookie;
 use Brick\Http\MessageBody;
+use Brick\Http\MessageBodyString;
 use Brick\Http\Response;
 
 use PHPUnit\Framework\TestCase;
@@ -111,6 +112,32 @@ class ResponseTest extends TestCase
         $this->assertSame('Hello World', (string) $response->getBody());
     }
 
+    public function testSetContentWithResource()
+    {
+        $response = new Response();
+
+        $this->assertSame($response, $response->setContent(fopen('php://input', 'rb')));
+        $this->assertInstanceOf(MessageBody::class, $response->getBody());
+        $this->assertSame('', (string) $response->getBody());
+    }
+
+    public function testIsStatusCode()
+    {
+        $response = new Response();
+
+        $this->assertTrue($response->isStatusCode(200));
+        $this->assertFalse($response->isStatusCode(400));
+    }
+
+    /**
+     * @expectedException        \RuntimeException
+     * @expectedExceptionMessage Could not parse response (error 1).
+     */
+    public function testParseShouldReturnRuntimeExceptionError1()
+    {
+        Response::parse('<!DCOTYPE html><html>HTML strings</html>');
+    }
+
     public function testIsType()
     {
         $response = new Response();
@@ -125,5 +152,98 @@ class ResponseTest extends TestCase
             $this->assertSame($digit == 4, $response->isClientError());
             $this->assertSame($digit == 5, $response->isServerError());
         }
+    }
+
+    public function testHasHeader()
+    {
+        $response = new Response();
+        //$resultTrue = $response->
+
+        $this->assertFalse($response->hasHeader('no_header_name'));
+    }
+
+    public function testAddHeaderWithArrayValue()
+    {
+        $response = new Response();
+
+        $this->assertInstanceOf(Response::class, $response->addHeader('Date', ['Sun', '18 Oct 2009 08:56:53 GMT']));
+        $this->assertSame('Sun, 18 Oct 2009 08:56:53 GMT', $response->getHeader('Date'));
+    }
+
+    public function testAddHeaderWithArrayValueAppendExistedHeader()
+    {
+        $response = new Response();
+        $response->addHeader('Date', 'Sun');
+        $response->addHeader('Date', ['18 Oct 2009 08:56:53 GMT']);
+
+        $this->assertSame('Sun, 18 Oct 2009 08:56:53 GMT', $response->getHeader('Date'));
+    }
+
+    public function testAddHeaders()
+    {
+        $response = new Response();
+        $result = $response->addHeaders([
+            'Content-Type' => 'text/html; charset=utf-8',
+            'Server' => 'Apache',
+        ]);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame('text/html; charset=utf-8', $response->getHeader('Content-Type'));
+        $this->assertSame('Apache', $response->getHeader('Server'));
+    }
+
+    public function testGetHead()
+    {
+        $response = new Response();
+        $response->addHeaders([
+            'Content-Type' => 'text/html; charset=utf-8',
+            'Server' => 'Apache',
+        ]);
+        $expectedHead = 'HTTP/1.0 200 OK' . "\r\n" . 'Content-Type: text/html; charset=utf-8' . "\r\n" . 'Server: Apache' . "\r\n\r\n";
+
+        $this->assertSame($expectedHead, $response->getHead());
+    }
+
+    public function testGetContentLength()
+    {
+        $response = new Response();
+
+        $this->assertSame(0, $response->getContentLength());
+    }
+
+    public function testGetContentLengthShouldReturn19730()
+    {
+        $response = new Response();
+        $response->addHeader('Content-Length', 19730);
+
+        $this->assertSame(19730, $response->getContentLength());
+    }
+
+    public function testIsContentType()
+    {
+        $response = new Response();
+        $response->addHeader('Content-Type', 'text/html; charset=utf-8');
+
+        $this->assertTrue($response->isContentType('text/html'));
+    }
+
+    public function testClassInstanceShouldReturnMessageBodyString()
+    {
+        $response = new Response();
+        $response->setBody(new MessageBodyString('param1=value1&param2=value2'));
+        $response->addHeader('Content-Length', 19730);
+        $expectedString = 'HTTP/1.0 200 OK' . "\r\n" . 'Content-Length: 27' . "\r\n" . 'Content-Length: 19730' . "\r\n\r\n" . 'param1=value1&param2=value2';
+
+        $this->assertSame($expectedString, (string)$response);
+    }
+
+    public function testClassInstanceShouldBeCloned()
+    {
+        $response = new Response();
+        $response->setBody(new MessageBodyString('param1=value1&param2=value2'));
+        $cloneResponse = clone $response;
+
+        $this->assertInstanceOf(Response::class, $cloneResponse);
+        $this->assertInstanceOf(MessageBodyString::class, $cloneResponse->getBody());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -118,7 +118,6 @@ class ResponseTest extends TestCase
         $response = new Response();
 
         $this->assertSame($response, $response->setContent(fopen('php://input', 'rb')));
-        $this->assertInstanceOf(MessageBody::class, $response->getBody());
         $this->assertInstanceOf(MessageBodyResource::class, $response->getBody());
         $this->assertSame(0, $response->getBody()->getSize());
     }
@@ -146,7 +145,7 @@ class ResponseTest extends TestCase
      */
     public function testParseShouldThrowRuntimeExceptionError2()
     {
-        Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length: 20' . "\r\n");
+        Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Type: text/plain' . "\r\n");
     }
 
     /**
@@ -155,27 +154,27 @@ class ResponseTest extends TestCase
      */
     public function testParseShouldThrowRuntimeExceptionError3()
     {
-        Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length20' . "\r\n\r\n");
+        Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Typetext/plain' . "\r\n\r\n");
     }
 
     public function testParseShouldReturnResponseObject()
     {
-        $result = Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length: 20' . "\r\n\r\n");
+        $result = Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Type: text/html' . "\r\n\r\n");
 
         $this->assertInstanceOf(Response::class, $result);
         $this->assertSame(200, $result->getStatusCode());
         $this->assertSame('1.0', $result->getProtocolVersion());
-        $this->assertSame(['Content-Length' => ['0']], $result->getHeaders());
+        $this->assertSame(['Content-Type' => ['text/html']], $result->getHeaders());
     }
 
     public function testParseWithCookieHeaderShouldReturnResponseObject()
     {
-        $result = Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length: 20' . "\r\n" . 'Set-Cookie: sessionid=38afes7a8; HttpOnly; Path=/' . "\r\n\r\n");
+        $result = Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Type: text/html' . "\r\n" . 'Set-Cookie: sessionid=38afes7a8; HttpOnly; Path=/' . "\r\n\r\n");
 
         $this->assertInstanceOf(Response::class, $result);
         $this->assertSame(200, $result->getStatusCode());
         $this->assertSame('1.0', $result->getProtocolVersion());
-        $this->assertSame(['Content-Length' => ['0'], 'Set-Cookie' => ['sessionid=38afes7a8; Path=/; HttpOnly']], $result->getHeaders());
+        $this->assertSame(['Content-Type' => ['text/html'], 'Set-Cookie' => ['sessionid=38afes7a8; Path=/; HttpOnly']], $result->getHeaders());
     }
 
     public function testIsType()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -138,6 +138,38 @@ class ResponseTest extends TestCase
         Response::parse('<!DCOTYPE html><html>HTML strings</html>');
     }
 
+    /**
+     * @expectedException        \RuntimeException
+     * @expectedExceptionMessage Could not parse response (error 2).
+     */
+    public function testParseShouldReturnRuntimeExceptionError2()
+    {
+        Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length: 20' . "\r\n");
+    }
+
+    /**
+     * @expectedException        \RuntimeException
+     * @expectedExceptionMessage Could not parse response (error 3).
+     */
+    public function testParseShouldReturnRuntimeExceptionError3()
+    {
+        Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length20' . "\r\n\r\n");
+    }
+
+    public function testParseShouldReturnResponseObject()
+    {
+        $result = Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length: 20' . "\r\n\r\n");
+
+        $this->assertInstanceOf(Response::class, $result);
+    }
+
+    public function testParseWithCookieHeaderShouldReturnResponseObject()
+    {
+        $result = Response::parse('HTTP/1.0 200 OK' . "\r\n" . 'Content-Length: 20' . "\r\n" . 'Set-Cookie: sessionid=38afes7a8; HttpOnly; Path=/' . "\r\n\r\n");
+
+        $this->assertInstanceOf(Response::class, $result);
+    }
+
     public function testIsType()
     {
         $response = new Response();

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -164,7 +164,7 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(Response::class, $result);
         $this->assertSame(200, $result->getStatusCode());
         $this->assertSame('1.0', $result->getProtocolVersion());
-        $this->assertSame(['Content-Type' => ['text/html']], $result->getHeaders());
+        $this->assertSame(['Content-Type' => ['text/html'], 'Content-Length' => ['0']], $result->getHeaders());
     }
 
     public function testParseWithCookieHeaderShouldReturnResponseObject()
@@ -174,7 +174,7 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(Response::class, $result);
         $this->assertSame(200, $result->getStatusCode());
         $this->assertSame('1.0', $result->getProtocolVersion());
-        $this->assertSame(['Content-Type' => ['text/html'], 'Set-Cookie' => ['sessionid=38afes7a8; Path=/; HttpOnly']], $result->getHeaders());
+        $this->assertSame(['Content-Type' => ['text/html'], 'Set-Cookie' => ['sessionid=38afes7a8; Path=/; HttpOnly'], 'Content-Length' => ['0']], $result->getHeaders());
     }
 
     public function testIsType()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -136,7 +136,7 @@ class ResponseTest extends TestCase
      */
     public function testParseShouldThrowRuntimeExceptionError1()
     {
-        Response::parse('<!DCOTYPE html><html>HTML strings</html>');
+        Response::parse('<!DOCTYPE html><html>HTML strings</html>');
     }
 
     /**

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Brick\Http\Tests;
+
+use Brick\Http\UploadedFile;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for class UploadedFile.
+ */
+class UploadedFileTest extends TestCase
+{
+    protected $uploadedFile;
+
+    protected function setUp()
+    {
+        $this->uploadedFile = UploadedFile::create([
+            'tmp_name' => 'uploaded_temp_file.txt',
+            'name' => 'uploaded_file.txt',
+            'type' => 'txt',
+            'size' => 1024,
+            'error' => 0,
+        ]);
+    }
+
+    public function testGetExtension()
+    {
+        $this->assertSame('txt', $this->uploadedFile->getExtension());
+    }
+
+    public function testIsValid()
+    {
+        $this->assertTrue($this->uploadedFile->isValid());
+    }
+
+    public function testIsSelected()
+    {
+        $this->assertTrue($this->uploadedFile->isSelected());
+    }
+}

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -29,13 +29,56 @@ class UploadedFileTest extends TestCase
         $this->assertSame('txt', $this->uploadedFile->getExtension());
     }
 
+    public function testGetPath()
+    {
+        $this->assertSame('uploaded_temp_file.txt', $this->uploadedFile->getPath());
+    }
+
+    public function testGetName()
+    {
+        $this->assertSame('uploaded_file.txt', $this->uploadedFile->getName());
+    }
+
+    public function testGetType()
+    {
+        $this->assertSame('txt', $this->uploadedFile->getType());
+    }
+
+    public function testGetSize()
+    {
+        $this->assertSame(1024, $this->uploadedFile->getSize());
+    }
+
+    public function testGetStatus()
+    {
+        $this->assertSame(0, $this->uploadedFile->getStatus());
+    }
+
     public function testIsValid()
     {
+        $uploadedFile = UploadedFile::create([
+            'tmp_name' => 'uploaded_temp_file.txt',
+            'name' => 'uploaded_file.txt',
+            'type' => 'txt',
+            'size' => 1024,
+            'error' => 1,
+        ]);
+
         $this->assertTrue($this->uploadedFile->isValid());
+        $this->assertFalse($uploadedFile->isValid());
     }
 
     public function testIsSelected()
     {
+        $uploadedFile = UploadedFile::create([
+            'tmp_name' => 'uploaded_temp_file.txt',
+            'name' => 'uploaded_file.txt',
+            'type' => 'txt',
+            'size' => 1024,
+            'error' => 4,
+        ]);
+
         $this->assertTrue($this->uploadedFile->isSelected());
+        $this->assertFalse($uploadedFile->isSelected());
     }
 }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -43,6 +43,15 @@ class UrlTest extends TestCase
     }
 
     /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage URL must contain a host name.
+     */
+    public function testConstructorUrlWithNoHostName()
+    {
+        $url = new Url('http:sub.site.org');
+    }
+
+    /**
      * @return array
      */
     public function providerValidUrl()


### PR DESCRIPTION
# Changed log

- In some tests, it should assert the true/false because ```substr``` function will not return false since PHP ```7.0.0```.
It will return empty string when the string is equal to start characters long.

- enhance the tests.
- In ```Response.php```, the ```setStatusCode``` parameter in ```parse```` method should be the integer type and I let the ```$statusCode``` cast to integer type.